### PR TITLE
Add H619D documentation (LAN/UDP)

### DIFF
--- a/Products/H619D.md
+++ b/Products/H619D.md
@@ -1,0 +1,198 @@
+# H619D
+
+## Contributors
+<table>
+   <tr>
+      <td align="center"><a href="https://github.com/jlepp"><b>jlepp</b></a></td>
+   </tr>
+</table>
+
+> **Protocol note:** The H619D supports both BLE and a LAN/UDP API. All findings here are for the **LAN API** — no Bluetooth sniffing required. The LAN API must be enabled in the Govee Home app under *Devices → (device) → More Settings → LAN Control*.
+
+---
+
+## Checklist of commands (LAN)
+- [x] Discovery
+- [x] Turn on/off
+- [x] Set brightness
+- [x] Set solid color (`colorwc`)
+- [x] Set color temperature (`colorwc`)
+- [x] Per-segment color control (`ptReal`)
+- [x] Query device status (`devStatus`)
+
+---
+
+## LAN API overview
+
+All communication is UDP. The device must have LAN Control enabled in the Govee Home app.
+
+| Port | Direction | Purpose |
+|------|-----------|---------|
+| 4001 | send      | Discovery (multicast) |
+| 4002 | receive   | All device responses and status |
+| 4003 | send      | Commands |
+
+**Important:** The device always replies to port **4002** on the sender's host — not back to whatever ephemeral port you sent from. To receive replies you must bind a socket to port 4002.
+
+All messages are JSON, sent and received as UTF-8.
+
+---
+
+## Discovery
+
+Send to multicast group `239.255.255.250:4001` (also works via broadcast `255.255.255.255`). The device responds on port 4002.
+
+**Request:**
+```json
+{"msg": {"cmd": "scan", "data": {"account_topic": "reserve"}}}
+```
+
+**Response:**
+```json
+{
+  "msg": {
+    "cmd": "scan",
+    "data": {
+      "ip": "192.168.x.x",
+      "device": "<device_id>",
+      "sku": "H619D",
+      "deviceName": "<friendly name>",
+      "bleVersionHard": "...",
+      "bleVersionSoft": "...",
+      "wifiVersionHard": "...",
+      "wifiVersionSoft": "..."
+    }
+  }
+}
+```
+
+---
+
+## Commands
+
+All commands are sent as JSON to `{device_ip}:4003`:
+
+```json
+{"msg": {"cmd": "<command>", "data": { ... }}}
+```
+
+### Turn on/off
+
+```json
+{"msg": {"cmd": "turn", "data": {"value": 1}}}   // on
+{"msg": {"cmd": "turn", "data": {"value": 0}}}   // off
+```
+
+### Set brightness
+
+`value` is 0–100 (integer percent).
+
+```json
+{"msg": {"cmd": "brightness", "data": {"value": 80}}}
+```
+
+`brightness` is safe to use alongside `ptReal` segment mode — it does not disrupt per-segment state.
+
+### Set solid color (`colorwc`)
+
+Sets the whole device to one RGB color. `colorTemInKelvin` must be `0` when using color.
+
+```json
+{"msg": {"cmd": "colorwc", "data": {"color": {"r": 255, "g": 100, "b": 0}, "colorTemInKelvin": 0}}}
+```
+
+**Warning:** Sending `colorwc` puts the device into solid-color mode and **silently breaks `ptReal`** — subsequent segment commands will be dropped with no error. The only recovery is a power cycle (`turn off` then `turn on`) before using `ptReal` again.
+
+### Set color temperature (`colorwc`)
+
+Set `color` to `{"r":0,"g":0,"b":0}` and provide a Kelvin value (approx. 2000–9000 K):
+
+```json
+{"msg": {"cmd": "colorwc", "data": {"color": {"r": 0, "g": 0, "b": 0}, "colorTemInKelvin": 4000}}}
+```
+
+### Query device status
+
+```json
+{"msg": {"cmd": "devStatus", "data": {}}}
+```
+
+Response arrives on port 4002.
+
+---
+
+## Per-segment color control (`ptReal`)
+
+The H619D has **15 addressable segments** (indices 0–14). Each segment maps to two mirrored physical spots (one on each of the device's two LED strands).
+
+### Physical layout
+
+The H619D has two LED strands that start together at the controller. Assuming you split and run in opposite directions from there, the addresses start at 0 closest to the controller and the increment from there. Unfortunately, the segment N lights one position on each strand simultaneously — the two spots are mirror images of each other. I have not found a way to light a segment in either strand independently - an area for further study.
+
+### Packet format
+
+Unlike some other Govee devices, the H619D does **not** accept raw hex LED data for `ptReal`. It requires a **base64-encoded 20-byte BLE-style packet**:
+
+```
+byte  0:     0x33          BLE command header
+bytes 1–2:   0x05 0x15     LED domain, color mode
+byte  3:     0x01          color subcommand
+bytes 4–6:   R  G  B       color (0–255 each)
+bytes 7–11:  0x00 × 5      color temperature (all zero = use color, not white)
+bytes 12–18: bitmask       7-byte little-endian integer; bit N = segment N is on
+byte  19:    checksum       XOR of bytes 0–18
+```
+
+Encode the resulting 20 bytes as **base64** and send as:
+
+```json
+{"msg": {"cmd": "ptReal", "data": {"command": ["<base64>"]}}}
+```
+
+To address segment N, set the bitmask to `(1 << N)` encoded as a 7-byte little-endian integer.
+
+**Example — set segment 0 to red (Python):**
+
+```python
+import base64, json, socket
+
+def make_ptreal_packet(seg: int, r: int, g: int, b: int) -> str:
+    bitmask = (1 << seg).to_bytes(7, "little")
+    data = bytes([0x33, 0x05, 0x15, 0x01, r, g, b,
+                  0x00, 0x00, 0x00, 0x00, 0x00]) + bitmask
+    chk = 0
+    for byte in data:
+        chk ^= byte
+    return base64.b64encode(data + bytes([chk])).decode()
+
+pkt = make_ptreal_packet(seg=0, r=255, g=0, b=0)
+payload = json.dumps({"msg": {"cmd": "ptReal", "data": {"command": [pkt]}}}).encode()
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.sendto(payload, ("192.168.x.x", 4003))
+```
+
+Multiple segments can be set in one command by ORing their bits in the bitmask — however, they will all be the same color.
+
+### Activating segment mode on startup
+
+If the device was last controlled via `colorwc`, `ptReal` commands are **silently ignored**. To enter segment mode reliably on startup, send one `ptReal` command per segment (any color):
+
+```python
+for s in range(15):
+    send_ptreal(seg=s, r=255, g=255, b=255)
+    time.sleep(0.05)  # see rate limit note below
+```
+
+You must also do this after any `turn off` / `turn on` cycle.
+
+---
+
+## Known quirks and gotchas
+
+| Issue | Detail |
+|-------|--------|
+| `colorwc` breaks `ptReal` | After any `colorwc` command, `ptReal` is silently ignored. Power-cycle the device (turn off + on) to recover. |
+| Rate limit on `ptReal` | Sending `ptReal` commands faster than ~20/s causes packets to be dropped silently. Allow ~50 ms between successive commands. |
+| Responses always go to port 4002 | Even if you send a command from an ephemeral port, the reply always arrives on port 4002 of your host. Bind a dedicated socket to 4002 to receive them. |
+| Raw hex LED data does NOT work | Other Govee devices accept raw hex for `ptReal`; the H619D requires base64-encoded BLE packets as described above. |
+| 15 segments, not a power of two | For the H619D I have, the segment count is 15 (indices 0–14). The bitmask field is 7 bytes, supporting up to 56 segments. There may be other variants of the Govee RGBIC LED strip with longer strands and more segments. |


### PR DESCRIPTION
 Documents the Govee H619D RGBIC LED strip via its LAN/UDP API (no BLE sniffing required).

  Key findings:
  - Full LAN protocol: discovery via UDP multicast to 239.255.255.250:4001, commands to port 4003,
  responses always arrive on port 4002
  - Per-segment control via `ptReal`: unlike some other Govee devices, the H619D requires a
  **base64-encoded 20-byte BLE-style packet** — raw hex LED data is silently ignored
  - Packet format: `0x33 0x05 0x15 0x01` header, RGB bytes, 5 temperature zeros, 7-byte little-endian
  segment bitmask, XOR checksum
  - 15 addressable segments (indices 0–14), each lighting two mirrored physical spots on the device's dual
  strands
  - Critical gotcha: `colorwc` (solid color mode) silently breaks subsequent `ptReal` commands — power
  cycle required to recover
  - Rate limit: ~50 ms needed between successive `ptReal` commands to avoid silent drops
