### PR TITLE
Add H6004, H6005, and H61F6: colour-temp 0x0D, instant music 0x05, per-model brightness, and an encrypted newer protocol

### DIFF
--- a/Products/H6004.md
+++ b/Products/H6004.md
@@ -1,0 +1,210 @@
+# H6004
+## Contributors
+<table>
+    <tr>
+        <td align="center"><a href="https://github.com/SimonDedman"><img src="https://github.com/SimonDedman.png" width="100px;"/><br/><sub><b>Simon Dedman</b></sub></a><br/></td>
+    </tr>
+</table>
+
+Wi-Fi + Bluetooth LE bulb, sold in packs sharing one wall switch. Everything
+below was captured from the official Android app with the phone's Bluetooth HCI
+snoop log, rebuilt byte-for-byte, and then confirmed against the bulbs. Frames
+that were only ever *guessed* are called out as such, because this bulb acks
+frames it ignores.
+
+The [H6005](H6005.md) uses the same command set with different limits.
+
+### Checklist of packets
+- [x] Keep alive
+- [x] Power
+- [x] Set global brightness
+- [x] Change colour
+- [x] Change colour temperature
+- [x] Enter music mode
+- [x] Stream colour in music mode
+- [ ] Scenes
+- [ ] DIY mode
+- [ ] Segment / addressable control (this is a plain bulb)
+
+## Transports
+
+| Transport | Works | Note |
+|---|---|---|
+| Bluetooth LE | yes | everything below |
+| Govee cloud API | yes | full colour and colour temperature |
+| Govee LAN API | **no** | the bulb does not answer the UDP multicast scan on `239.255.255.250:4001`. This is a missing feature of the model, not a setting to enable |
+
+The Wi-Fi MAC is the BLE MAC **minus one**, which is handy for matching a bulb
+seen on the LAN to one seen on the air.
+
+## GATT
+
+```
+service      00010203-0405-0607-0809-0a0b0c0d1910
+control      00010203-0405-0607-0809-0a0b0c0d2b11   properties: read, write-without-response
+notify       00010203-0405-0607-0809-0a0b0c0d2b10   properties: read, notify
+```
+
+### The control characteristic must be written WITHOUT a response
+
+The control characteristic advertises only `write-without-response`, so a
+write **request** is protocol-illegal on it. The H6004 enforces that. BlueZ
+returns:
+
+```
+[org.bluez.Error.NotPermitted] Write not permitted
+```
+
+The [H6005](H6005.md) advertises exactly the same properties and yet accepts a
+write request anyway, so this is a firmware difference between the two models
+and not a property of your Bluetooth adapter. I confirmed that by driving both
+bulbs from two different controllers (a CSR8510 and an RTL8761BU): the H6004
+refused on both, the H6005 accepted on both.
+
+Worth knowing because the failure is quiet in the wrong direction. If your
+stack defaults to write-with-response you will get an exception on every
+write to an H6004 while the same code works perfectly on other Govee bulbs.
+
+In Bleak: `await client.write_gatt_char(CTRL, frame, response=False)`.
+
+## Frame format
+
+20 bytes: `0x33`, command, payload, zero-padded to 19 bytes, then an XOR of
+those 19 bytes as byte 20. The keepalive is the exception and uses its own
+`0xAA` header.
+
+```
+0x33   command indicator
+0xAA   keep alive
+```
+
+```
+0x01  power        [0x00 | 0x01]
+0x04  brightness   [level]
+0x05  colour       [sub-command, ...]
+```
+
+## Commands
+
+### Power
+
+```
+3301010000000000000000000000000000000033   on
+3301000000000000000000000000000000000032   off
+```
+
+### Brightness: this model is 0-100, not 0-255
+
+```
+3304640000000000000000000000000000000053   100%
+```
+
+The app sends `0x01` for 1% and `0x64` for 100%. `0xFF` also renders as full
+because it is clamped, which is exactly why a scale error here can go unnoticed
+for a long time: the [H6005](H6005.md) is genuinely 0-255, and a shared
+constant is silently wrong on one model or the other. Send what the app sends.
+
+### Colour and colour temperature: sub-command `0x0D`
+
+```
+colour             0x33 05 0D  R G B
+colour temperature 0x33 05 0D  R G B  K_hi K_lo  R G B     <- RGB repeated
+```
+
+Kelvin is a plain 16-bit big-endian value. This bulb floors at 2700 K, matching
+the range its own cloud API reports.
+
+```
+33050dff000000000000000000000000000000c4   red
+33050dffa9570a8cffa9570000000000000000bd   2700 K
+33050deeefff1d4ceeefff00000000000000006a   7500 K
+33050dd9e1ff2328d9e1ff000000000000000030   9000 K
+```
+
+**The sub-command is `0x0D`, not the `0x02` "manual" of the H6001 generation.**
+An `0x02` frame is acked and then silently ignored. That one byte is why
+plausible guessed frames appear to work at the protocol level while the bulb
+never changes.
+
+### `0x0D` fades. For streaming, use music mode
+
+`0x0D` ramps to its colour over roughly 0.3 to 1 s. That is fine for a scene
+and useless for streaming: at 12 Hz each frame interrupts the previous ramp and
+the bulb never arrives, so a red/green alternation renders as a muted orange.
+The app's music mode uses a separate sub-command that applies immediately:
+
+```
+3305050100000000000000000000000000000032   enter music mode
+33050500ff0000000000000000000000000000cc   set colour NOW (red)
+```
+
+```
+0x33 05 05 01              enter music mode
+0x33 05 05 00  R G B       set colour immediately
+```
+
+Driven from Linux, the same 12 Hz test gives sharp saturated colours with
+`0x05` where `0x0D` gave mush. The app streams these at about 20 Hz and
+computes its own decay envelope in software (`fe → aa → 56 → 14`, one frame
+per step), which only makes sense because `0x05` steps instantly.
+
+**Send the enter frame once per session.** The app does. Re-sending it about
+once a second, as a defence against a lost write, left bulbs in a state where
+they still obeyed `0x05` colour frames but ignored power, brightness, and
+`0x0D` entirely, and a mains power cycle did not clear it.
+
+### Keepalive
+
+```
+aa010000000000000000000000000000000000ab
+```
+
+Its own `0xAA` header rather than a `0x33` frame, and the checksum still covers
+the first 19 bytes. The app sends it about every 2 s.
+
+The bulb hangs up an idle link after roughly 15 s, and **only a write resets
+that timer**. A GATT read does not: measured over a minute, reads gave 18
+disconnects where writes gave 6. This frame is the right keepalive precisely
+because it is a no-op, so it cannot fight whatever else is setting the light.
+
+## Acks prove receipt, never compliance
+
+Every frame is acked on the notify characteristic with the command byte echoed
+and a zeroed payload:
+
+```
+33 01 ...   ack of a power frame
+33 04 ...   ack of a brightness frame
+33 05 ...   ack of a colour frame
+```
+
+The ack is **identical whether the bulb acts on the frame or ignores it**. The
+rejected `0x02` sub-command above is acked exactly like a working `0x0D` one.
+This is the single most misleading thing about the protocol: it means a clean
+ack tells you twenty bytes arrived, and tells you nothing at all about whether
+they meant anything to the bulb. Verify by looking at the light, or by reading
+state back over the cloud API.
+
+One caveat on that readback: the cloud reflects a **brightness** set over
+Bluetooth, but not a **colour** set over Bluetooth. So it is a valid instrument
+for brightness experiments and an invalid one for colour.
+
+## Behaviour at mains power-on
+
+The bulb **restores its last state** when mains power returns, colour and
+on/off included. There is no power-on-behaviour setting in the app for this
+model, so whatever was last written is what a wall switch brings back.
+
+This matters if the bulbs share a wall switch with people who do not use the
+app: leave one on red and the next person to use the switch gets red.
+
+## Telling "off at the wall" from "off in software"
+
+A bulb switched off at the wall loses its radio and **stops advertising**. A
+bulb turned off with an `0x01 0x00` power frame is still powered and **keeps
+advertising** normally. So a passive advertisement scan distinguishes the two
+cleanly, without needing a connection, which is useful if you want to notice
+that a group has lost mains power.
+
+Do be careful to treat a failed scan differently from an empty one. A BlueZ
+error and a genuinely absent bulb look identical if you only count results.

--- a/Products/H6005.md
+++ b/Products/H6005.md
@@ -1,0 +1,68 @@
+# H6005
+## Contributors
+<table>
+    <tr>
+        <td align="center"><a href="https://github.com/SimonDedman"><img src="https://github.com/SimonDedman.png" width="100px;"/><br/><sub><b>Simon Dedman</b></sub></a><br/></td>
+    </tr>
+</table>
+
+Bluetooth LE bulb, no Wi-Fi. It never appears on the LAN and has no cloud
+presence, so BLE is the only way in.
+
+**The command set is identical to the [H6004](H6004.md)**, which carries the
+full write-up: GATT handles, frame format, the `0x0D` colour-temperature
+sub-command, the instant `0x05` music sub-command, the `0xAA` keepalive, and the
+warning that acks prove receipt and not compliance. Only the differences are
+listed here.
+
+### Checklist of packets
+- [x] Keep alive
+- [x] Power
+- [x] Set global brightness
+- [x] Change colour
+- [x] Change colour temperature
+- [x] Enter music mode
+- [x] Stream colour in music mode
+- [ ] Scenes
+- [ ] DIY mode
+
+## Differences from the H6004
+
+### Brightness is 0-255
+
+```
+3304ff00000000000000000000000000000000c8   100%
+```
+
+`0x64` is **39%** on this model, not 100%. It looked merely "a bit dim" for over
+a week before I measured it. The [H6004](H6004.md) is 0-100 and clamps `0xFF`
+to full, so a single shared brightness constant will be wrong on one of the two
+models whichever value you pick.
+
+### It reaches 2000 K
+
+Warmer than the H6004's 2700 K floor.
+
+```
+33050dff8d0b07d0ff8d0b0000000000000000ec   2000 K
+```
+
+### It tolerates a write with response
+
+The control characteristic advertises only `write-without-response` on both
+models, so a write request is protocol-illegal on both. The H6005 accepts one
+anyway; the H6004 refuses it with `[org.bluez.Error.NotPermitted]`. I confirmed
+this on two different controllers (a CSR8510 and an RTL8761BU) with the bulbs
+swapped between them, so it is firmware, not the adapter.
+
+Write without a response on both and the difference stops mattering. If you do
+use write-with-response on this model, be aware you are relying on the firmware
+being lenient about something it never advertised.
+
+## Radio note, in case it saves someone a day
+
+Both models advertise only while they have mains power, and a bulb that is off
+because you sent it `0x01 0x00` still advertises normally. So a scan that
+returns nothing usually means somebody used the wall switch, not that your
+adapter has failed. I lost a good while to "the adapter cannot see the bulbs"
+twice before checking the switch.

--- a/Products/H61F6.md
+++ b/Products/H61F6.md
@@ -1,0 +1,85 @@
+# H61F6
+## Contributors
+<table>
+    <tr>
+        <td align="center"><a href="https://github.com/SimonDedman"><img src="https://github.com/SimonDedman.png" width="100px;"/><br/><sub><b>Simon Dedman</b></sub></a><br/></td>
+    </tr>
+</table>
+
+Strip Light 2 Pro. **This is a negative result**: its Bluetooth protocol is
+encrypted and I did not break it. It is documented here so nobody else spends a
+week guessing sub-commands at it, and because the LAN and cloud paths do work.
+
+### Checklist of packets
+- [ ] Anything at all over BLE (encrypted, see below)
+- [x] Power, brightness, colour over the Govee **LAN API**
+- [x] Per-segment colour over the Govee **cloud API**
+
+## Govee runs two BLE protocols, and this device uses the second one
+
+```
+handle 0x0011   the plain 0x33 protocol, used by the older bulbs (H6004, H6005)
+handle 0x0016   20-byte ENCRYPTED payloads, used by this strip
+```
+
+The familiar `…2b11` characteristic is present on the strip, so it looks
+addressable. It is not. Every plain `0x33` frame sent to it, both the `0x0D`
+colour sub-command and the `0x0B` segment one, was correctly ignored, because
+it is waiting for ciphertext.
+
+### Replay does not work either. Do not spend time on it
+
+Captured ciphertext frames replayed to handle `0x0016` made the strip
+**disconnect within 2.5 s of the first frame**, where plain frames on `…2b11`
+were merely ignored and the link survived. So it parses the frame, rejects it,
+and drops the connection: an authentication failure rather than indifference.
+
+Evidence had pointed the other way at first, which is why this is worth
+recording. Identical ciphertext repeated 92 s apart, so there is no
+per-*message* counter. But the three bytes before the final byte vary between
+connections and even within one (`2eb71d`, `44b71d`, `58de37`), which fits a
+per-*connection* session token established at handshake. Breaking this needs
+key extraction from the APK.
+
+### Also learned while capturing
+
+- The keepalive on the plain protocol is `aa 01 00 … ab`, sent about every 2 s.
+- Sending `brightness 0xFF` to this strip over BLE **drops the link**. Its
+  brightness scale is 1-100.
+- In an Android bugreport, the btsnoop timestamps ran 7 h behind local time,
+  exactly the local UTC offset. Add it back before correlating with anything.
+
+## What does work
+
+**LAN API**, no cloud and no dependencies. UDP multicast scan to
+`239.255.255.250:4001`, listen on `4002`, control on `4003`.
+
+```
+scan     {"msg":{"cmd":"scan","data":{"account_topic":"reserve"}}}
+status   {"msg":{"cmd":"devStatus","data":{}}}     unicast to :4003
+```
+
+`devStatus` returns `onOff`, `brightness`, `color`, and `colorTemInKelvin`.
+
+One quirk worth knowing: this strip's LED driver **crossfades**. It blends
+rather than steps at any update rate I tried, and at 2.5 Hz it was still
+blending. The reported state flips instantly, so the fade is display-side and
+invisible to a readback. That rules the LAN path out for music-style streaming
+while making it pleasant for ambient effects.
+
+**Per-segment colour** is a cloud API capability and is unaffected by the BLE
+encryption.
+
+```
+POST /device/control
+  capability.type     devices.capabilities.segment_color_setting
+  capability.instance segmentedColorRgb
+  capability.value    {"segment": [0,1,2,3,4], "rgb": 16711680}
+```
+
+Segments are `0-14`, up to 15 addressed per call, and the list may be arbitrary
+rather than a contiguous range. Each call takes about 450 ms.
+
+Note that a long strip can have physical length beyond the 15 addressable
+segments: on mine the last quarter did not respond to any segment index, while
+a whole-strip LAN colour lit it.

--- a/README.md
+++ b/README.md
@@ -22,12 +22,16 @@ With all that out of the way, on to the documentation!
 | H5082   | [Click Here](Products/H5082) |             |
 | H5086   | [Click Here](Products/H5086.md) |             |
 | H6001   | [Click Here](Products/H6001.md) |             |
+| H6004   | [Click Here](Products/H6004.md) |             |
+| H6005   | [Click Here](Products/H6005.md) |             |
 | H6053   | [Click Here](Products/H6053.md) |             |
 | H6072   | [Click Here](Products/H6072.md) |             |
 | H6102   | [Click Here](Products/H6102.md) |             |
 | H6113   | [Click Here](Products/H6113.md) |             |
 | H6127   | [Click Here](Products/H6127.md) |             |
 | H6199   | [Click Here](Products/H6199.md) |             |
+| H619D   | [Click Here](Products/H619D.md) |             |
+| H61F6   | [Click Here](Products/H61F6.md) |             |
 
 ## Contributing
 Please feel free to make pull requests or issues with new products, or updated documentation for existing products. I want to exmand this repo to as many products to serve as a hub for reverse enginering Govee's products.


### PR DESCRIPTION
Following up on #24, where you kindly offered to take these as a PR.

Three products, none currently in the repo. Everything was captured from the Android app with the phone's HCI snoop log, rebuilt byte-for-byte, and then confirmed on the hardware. Anything I only inferred is labelled as such.

**H6004** (Wi-Fi + BLE bulb) carries the full write-up:

- Colour and colour temperature are sub-command **`0x0D`**, not the `0x02` "manual" of the H6001 generation. These bulbs **ack an `0x02` frame and then ignore it**, which is why guessed frames look like they work.
- Kelvin is plain 16-bit big-endian. This model floors at 2700 K.
- `0x0D` **fades** over roughly 0.3 to 1 s, so it cannot be streamed. The app's music mode uses `0x33 05 05 01` to enter and `0x33 05 05 00 R G B` to set a colour **instantly**, streamed at about 20 Hz. Send the enter frame **once**: repeating it wedged bulbs into a state that ignored power, brightness, and `0x0D`, and that a mains cycle did not clear.
- Brightness on this model is **0-100**, and `0xFF` is clamped so the error hides. The H6005 is genuinely **0-255**, where `0x64` is 39%.
- The keepalive is `aa 01 00 … ab`, its own `0xAA` header, about every 2 s. Bulbs drop an idle link after ~15 s and **only a write resets that timer**; a GATT read does not.
- **Acks prove receipt, never compliance.** The ack for a frame the bulb ignores is identical to one it obeys.
- The control characteristic advertises only `write-without-response`, so a write **request** is protocol-illegal. The **H6004 enforces that** and BlueZ returns `[org.bluez.Error.NotPermitted]`; the **H6005 accepts it anyway**. I confirmed this is firmware and not the adapter by driving both bulbs from both a CSR8510 and an RTL8761BU. If your stack defaults to write-with-response, every H6004 write fails while other Govee bulbs work fine.
- These bulbs **restore their last state on mains power-on**, and there is no power-on-behaviour setting in the app.
- A bulb off **at the wall** stops advertising; a bulb off via `0x01 0x00` keeps advertising. A passive scan tells the two apart without connecting.

**H6005** (BLE-only bulb) shares the command set, so its page lists only the differences: 0-255 brightness, a 2000 K floor, and the write-type quirk above.

**H61F6** (Strip Light 2 Pro) is a **negative result**, written up so nobody repeats it. Govee runs two BLE protocols: the plain `0x33` one on handle `0x0011`, and **encrypted** 20-byte payloads on handle `0x0016`, which this strip uses. Plain frames are ignored, and **replayed ciphertext makes it disconnect within 2.5 s**, so it authenticates rather than merely not caring. Identical ciphertext repeats across 92 s, so there is no per-message counter, but three bytes vary between and within connections, consistent with a per-connection session token. Its working paths are the LAN API and cloud segment control, both documented on the page.

Also adds the missing README row for `Products/H619D.md`, which exists but was not listed. Happy to drop that if you would rather keep it separate.

Happy to adjust the layout, split this into separate PRs, or drop the H61F6 page if a negative result is not what you want in `Products/`.